### PR TITLE
Update to new version of expandable side nav

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sass": "1.46.0",
     "postcss": "8.4.5",
     "postcss-cli": "8.3.1",
-    "vanilla-framework": "3.6.1"
+    "vanilla-framework": "3.7.0"
   },
   "devDependencies": {
     "prettier": "2.5.1",

--- a/static/js/docs-side-nav.js
+++ b/static/js/docs-side-nav.js
@@ -1,0 +1,160 @@
+(function () {
+  /**
+      Toggles the expanded/collapsed classed on side navigation element.
+
+      @param {HTMLElement} sideNavigation The side navigation element.
+      @param {Boolean} show Whether to show or hide the drawer.
+    */
+  function toggleDrawer(sideNavigation, show) {
+    const toggleButtonOutsideDrawer = sideNavigation.querySelector(
+      ".p-side-navigation__toggle"
+    );
+    const toggleButtonInsideDrawer = sideNavigation.querySelector(
+      ".p-side-navigation__toggle--in-drawer"
+    );
+
+    if (sideNavigation) {
+      if (show) {
+        sideNavigation.classList.remove("is-drawer-collapsed");
+        sideNavigation.classList.add("is-drawer-expanded");
+
+        toggleButtonInsideDrawer.focus();
+        toggleButtonOutsideDrawer.setAttribute("aria-expanded", true);
+        toggleButtonInsideDrawer.setAttribute("aria-expanded", true);
+      } else {
+        sideNavigation.classList.remove("is-drawer-expanded");
+        sideNavigation.classList.add("is-drawer-collapsed");
+
+        toggleButtonOutsideDrawer.focus();
+        toggleButtonOutsideDrawer.setAttribute("aria-expanded", false);
+        toggleButtonInsideDrawer.setAttribute("aria-expanded", false);
+      }
+    }
+  }
+
+  // throttle util (for window resize event)
+  var throttle = function (fn, delay) {
+    var timer = null;
+    return function () {
+      var context = this,
+        args = arguments;
+      clearTimeout(timer);
+      timer = setTimeout(function () {
+        fn.apply(context, args);
+      }, delay);
+    };
+  };
+
+  /**
+        Attaches event listeners for the side navigation toggles
+        @param {HTMLElement} sideNavigation The side navigation element.
+      */
+  function setupSideNavigation(sideNavigation) {
+    var toggles = [].slice.call(
+      sideNavigation.querySelectorAll(".js-drawer-toggle")
+    );
+    var drawerEl = sideNavigation.querySelector(".p-side-navigation__drawer");
+
+    // hide navigation drawer on small screens
+    sideNavigation.classList.add("is-drawer-hidden");
+
+    // setup drawer element
+    drawerEl.addEventListener("animationend", () => {
+      if (!sideNavigation.classList.contains("is-drawer-expanded")) {
+        sideNavigation.classList.add("is-drawer-hidden");
+      }
+    });
+
+    window.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") {
+        toggleDrawer(sideNavigation, false);
+      }
+    });
+
+    // setup toggle buttons
+    toggles.forEach(function (toggle) {
+      toggle.addEventListener("click", function (event) {
+        event.preventDefault();
+
+        if (sideNavigation) {
+          sideNavigation.classList.remove("is-drawer-hidden");
+          toggleDrawer(
+            sideNavigation,
+            !sideNavigation.classList.contains("is-drawer-expanded")
+          );
+        }
+      });
+    });
+
+    // hide side navigation drawer when screen is resized
+    window.addEventListener(
+      "resize",
+      throttle(function () {
+        toggles.forEach((toggle) => {
+          return toggle.setAttribute("aria-expanded", false);
+        });
+        // remove expanded/collapsed class names to avoid unexpected animations
+        sideNavigation.classList.remove("is-drawer-expanded");
+        sideNavigation.classList.remove("is-drawer-collapsed");
+        sideNavigation.classList.add("is-drawer-hidden");
+      }, 10)
+    );
+  }
+
+  /**
+        Attaches event listeners for all the side navigations in the document.
+        @param {String} sideNavigationSelector The CSS selector matching side navigation elements.
+      */
+  function setupSideNavigations(sideNavigationSelector) {
+    // Setup all side navigations on the page.
+    var sideNavigations = [].slice.call(
+      document.querySelectorAll(sideNavigationSelector)
+    );
+
+    sideNavigations.forEach(setupSideNavigation);
+  }
+
+  setupSideNavigations('.p-side-navigation, [class*="p-side-navigation--"]');
+
+  // Setup expandable side navigation
+
+  var expandToggles = document.querySelectorAll(".p-side-navigation__expand");
+  var navigationLinks = document.querySelectorAll(".p-side-navigation__link");
+
+  // setup default values of aria-expanded for the toggle button, list title and list itself
+  const setup = (toggle) => {
+    const isExpanded = toggle.getAttribute("aria-expanded") === "true";
+    if (!isExpanded) {
+      toggle.setAttribute("aria-expanded", isExpanded);
+    }
+    const item = toggle.closest(".p-side-navigation__item");
+    const link = item.querySelector(".p-side-navigation__link");
+    const nestedList = item.querySelector(".p-side-navigation__list");
+    if (!link?.hasAttribute("aria-expanded")) {
+      link.setAttribute("aria-expanded", isExpanded);
+    }
+    if (!nestedList?.hasAttribute("aria-expanded")) {
+      nestedList.setAttribute("aria-expanded", isExpanded);
+    }
+  };
+
+  const handleToggle = (e) => {
+    const item = e.currentTarget.closest(".p-side-navigation__item");
+    const button = item.querySelector(".p-side-navigation__expand");
+    const link = item.querySelector(".p-side-navigation__link");
+    const nestedList = item.querySelector(".p-side-navigation__list");
+    [button, link, nestedList].forEach((el) =>
+      el.setAttribute(
+        "aria-expanded",
+        el.getAttribute("aria-expanded") === "true" ? "false" : "true"
+      )
+    );
+  };
+
+  expandToggles.forEach((toggle) => {
+    setup(toggle);
+    toggle.addEventListener("click", (e) => {
+      handleToggle(e);
+    });
+  });
+})();

--- a/templates/docs/document.html
+++ b/templates/docs/document.html
@@ -3,29 +3,33 @@
 {% block title %}{{ document.title }} | Multipass documentation{% endblock %}
 
 {% block content %}
-{% macro create_navigation(nav_items, expandable=False) %}
+{% macro create_navigation(nav_items, expandable=False, expanded=False) %}
   <ul class="p-side-navigation__list">
     {% for element in nav_items %}
     <li class="p-side-navigation__item">
       {% if element.navlink_href %}
-      <a class="p-side-navigation__link" href="{{ element.navlink_href }}"
+      <a
+        class="p-side-navigation__link {% if expandable and element.children %}is-expandable{% endif %}"
+        href="{{ element.navlink_href }}"
+        {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}{% endif %}
         {% if element.is_active %}aria-current="page"{% endif %}
       >{{ element.navlink_text }}</a>
       {% else %}
-        <strong class="p-side-navigation__text">{{ element.navlink_text }}</strong>
+        <span
+          class="p-side-navigation__text {% if expandable and element.children %}is-expandable{% endif %}"
+          {% if expandable and element.children %}aria-expanded={% if expanded %}"true"{% else %}"false"{% endif %}{% endif %}
+          {% if element.is_active %}aria-current="page"{% endif %}
+        >{{ element.navlink_text }}</span>
       {% endif %}
 
       {% if expandable %}
-        {% if element.navlink_href %}
-          {% if element.children and (element.is_active or element.has_active_child) %}
-            {{ create_navigation(element.children, True) }}
-          {% endif %}
-        {% else %}
-          {{ create_navigation(element.children, True) }}
+        {% if element.children %}
+            <button class="p-side-navigation__expand" aria-expanded={% if element.is_active or element.has_active_child %}"true"{% else %}"false"{% endif %} aria-label="show submenu for {{ element.navlink_text }}"></button>
         {% endif %}
+        {{ create_navigation(element.children, expandable, element.is_active or element.has_active_child) }}
       {% else %}
         {% if element.children %}
-          {{ create_navigation(element.children, False) }}
+          {{ create_navigation(element.children, expandable) }}
         {% endif %}
       {% endif %}
     </li>
@@ -95,4 +99,5 @@
 </section>
 
 <script src="{{ versioned_static('js/prism.js') }}"></script>
+<script src="{{ versioned_static('js/docs-side-nav.js') }}"></script>
 {% endblock %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -374,13 +374,13 @@ autoprefixer@10.4.1:
     picocolors "^1.0.0"
     postcss-value-parser "^4.2.0"
 
-autoprefixer@10.4.7:
-  version "10.4.7"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.7.tgz#1db8d195f41a52ca5069b7593be167618edbbedf"
-  integrity sha512-ypHju4Y2Oav95SipEcCcI5J7CGPuvz8oat7sUtYj3ClK44bldfvtvcxK6IEK++7rqB7YchDGzweZIBG+SD0ZAA==
+autoprefixer@10.4.8:
+  version "10.4.8"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.8.tgz#92c7a0199e1cfb2ad5d9427bd585a3d75895b9e5"
+  integrity sha512-75Jr6Q/XpTqEf6D2ltS5uMewJIx5irCU1oBYJrWjFenq/m12WRRrz6g15L1EIoYvPLXTbEry7rDOwrcYNj77xw==
   dependencies:
-    browserslist "^4.20.3"
-    caniuse-lite "^1.0.30001335"
+    browserslist "^4.21.3"
+    caniuse-lite "^1.0.30001373"
     fraction.js "^4.2.0"
     normalize-range "^0.1.2"
     picocolors "^1.0.0"
@@ -456,16 +456,15 @@ browserslist@^4.19.1:
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
-browserslist@^4.20.3:
-  version "4.20.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.20.3.tgz#eb7572f49ec430e054f56d52ff0ebe9be915f8bf"
-  integrity sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==
+browserslist@^4.21.3:
+  version "4.21.3"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.21.3.tgz#5df277694eb3c48bc5c4b05af3e8b7e09c5a6d1a"
+  integrity sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==
   dependencies:
-    caniuse-lite "^1.0.30001332"
-    electron-to-chromium "^1.4.118"
-    escalade "^3.1.1"
-    node-releases "^2.0.3"
-    picocolors "^1.0.0"
+    caniuse-lite "^1.0.30001370"
+    electron-to-chromium "^1.4.202"
+    node-releases "^2.0.6"
+    update-browserslist-db "^1.0.5"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -496,10 +495,10 @@ caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001294:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001296.tgz#d99f0f3bee66544800b93d261c4be55a35f1cec8"
   integrity sha512-WfrtPEoNSoeATDlf4y3QvkwiELl9GyPLISV5GejTbbQRtQx4LhsXmc9IQ6XCL2d7UxCyEzToEZNMeqR79OUw8Q==
 
-caniuse-lite@^1.0.30001332, caniuse-lite@^1.0.30001335:
-  version "1.0.30001341"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz#59590c8ffa8b5939cf4161f00827b8873ad72498"
-  integrity sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==
+caniuse-lite@^1.0.30001370, caniuse-lite@^1.0.30001373:
+  version "1.0.30001388"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001388.tgz#88e01f4591cbd81f9f665f3f078c66b509fbe55d"
+  integrity sha512-znVbq4OUjqgLxMxoNX2ZeeLR0d7lcDiE5uJ4eUiWdml1J1EkxbnQq6opT9jb9SMfJxB0XA16/ziHwni4u1I3GQ==
 
 chalk@^2.0.0, chalk@^2.4.2:
   version "2.4.2"
@@ -751,15 +750,15 @@ electron-to-chromium@^1.3.723:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.737.tgz#196f2e9656f4f3c31930750e1899c091b72d36b5"
   integrity sha512-P/B84AgUSQXaum7a8m11HUsYL8tj9h/Pt5f7Hg7Ty6bm5DxlFq+e5+ouHUoNQMsKDJ7u4yGfI8mOErCmSH9wyg==
 
-electron-to-chromium@^1.4.118:
-  version "1.4.137"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz#186180a45617283f1c012284458510cd99d6787f"
-  integrity sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA==
-
 electron-to-chromium@^1.4.17:
   version "1.4.36"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.36.tgz#446c6184dbe5baeb5eae9a875490831e4bc5319a"
   integrity sha512-MbLlbF39vKrXWlFEFpCgDHwdlz4O3LmHM5W4tiLRHjSmEUXjJjz8sZkMgWgvYxlZw3N1iDTmCEtOkkESb5TMCg==
+
+electron-to-chromium@^1.4.202:
+  version "1.4.240"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.240.tgz#b11fb838f2e79f34fbe8b57eec55e7e5d81ee6ea"
+  integrity sha512-r20dUOtZ4vUPTqAajDGonIM1uas5tf85Up+wPdtNBNvBSqGCfkpvMVvQ1T8YJzPV9/Y9g3FbUDcXb94Rafycow==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -1617,10 +1616,10 @@ node-releases@^2.0.1:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.1.tgz#3d1d395f204f1f2f29a54358b9fb678765ad2fc5"
   integrity sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==
 
-node-releases@^2.0.3:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.4.tgz#f38252370c43854dc48aa431c766c6c398f40476"
-  integrity sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==
+node-releases@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
+  integrity sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -2113,10 +2112,10 @@ sass@1.46.0:
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
 
-sass@1.53.0:
-  version "1.53.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.53.0.tgz#eab73a7baac045cc57ddc1d1ff501ad2659952eb"
-  integrity sha512-zb/oMirbKhUgRQ0/GFz8TSAwRq2IlR29vOUJZOx0l8sV+CkHUfHa4u5nqrG+1VceZp7Jfj59SVW9ogdhTvJDcQ==
+sass@1.54.0:
+  version "1.54.0"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.54.0.tgz#24873673265e2a4fe3d3a997f714971db2fba1f4"
+  integrity sha512-C4zp79GCXZfK0yoHZg+GxF818/aclhp9F48XBu/+bm9vXEVAYov9iU3FBVRMq3Hx3OA4jfKL+p2K9180mEh0xQ==
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
@@ -2486,6 +2485,14 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
+update-browserslist-db@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.6.tgz#044fddb5c26989628da5cff7a82ce1472152bce6"
+  integrity sha512-We7BqM9XFlcW94Op93uW8+2LXvGezs7QA0WY+f1H7RR1q46B06W6hZF6LbmOlpCS1HU22q/6NOGTGW5sCm7NJQ==
+  dependencies:
+    escalade "^3.1.1"
+    picocolors "^1.0.0"
+
 uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
@@ -2523,18 +2530,18 @@ vanilla-framework@3.0.1:
     postcss-cli "9.1.0"
     sass "1.45.2"
 
-vanilla-framework@3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.6.1.tgz#976a857b658f5bab65ad8f7898ad2dbff6530f9e"
-  integrity sha512-QFqArcGr1w/VyWTkWU8ftP9xyM3jYVyyxxMBKSzbDRwgt7PxZyalCJ16C8QjwM9S/ihkH1V3258Lxh1ZSfcw1A==
+vanilla-framework@3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-3.7.0.tgz#0468fb03011d8792ed3f25f4fec36ac5f5af0ea4"
+  integrity sha512-NCwqj17vRkz+tCv4PXvyaOVLZB2/a/+rtlccPlqThNmfn4FPcXVwG3jVokeNWH9rIIus3vr1SBVs/a/B69Ljjg==
   dependencies:
     "@canonical/cookie-policy" "3.4.0"
     "@canonical/latest-news" "1.4.1"
-    autoprefixer "10.4.7"
+    autoprefixer "10.4.8"
     postcss "8.4.14"
     postcss-cli "9.1.0"
     postcss-scss "4.0.4"
-    sass "1.53.0"
+    sass "1.54.0"
     yaml "1.10.2"
 
 verbalize@^0.1.2:


### PR DESCRIPTION
Updates the side navigation to latest version (as per example in https://github.com/canonical/canonicalwebteam.discourse/pull/143)
Drive-by: upgrade Vanilla to 3.7

Demo: https://multipass-run-267.demos.haus/docs

### QA

Visit docs: https://multipass-run-267.demos.haus/docs
Make sure expandable side nav works as expected.