### PR TITLE
Revive cheat sheet section

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -44,6 +44,18 @@
   </div>
 </section>
 
+<section class="p-strip--suru-accent">
+  <div class="row u-equal-height u-vertically-center">
+    <div class="col-6 u-align--center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/39a8dac8-Ubuntu_Server_CLI_pro_tips_2020-04.jpg" style="height: 280px; width: 400px;" alt="Ubuntu Server CLI pro tips"/>
+    </div>
+    <div class="col-6">
+      <p>The “Ubuntu Server CLI cheat sheet” is your fast path to learning the Linux command line - from basic file management to deploying Kubernetes and OpenStack.</p>
+      <a class="p-link--external p-button--positive" target="blank" href="https://assets.ubuntu.com/v1/bb21c0e8-Ubuntu+Server+CLI+pro+tips+06.01.20.pdf">Download Cheat Sheet</a>
+    </div>
+  </div>
+</section>
+
 <section class="p-strip">
   <div class="row u-equal-height u-vertically-center">
     <div class="col-5 u-align--center  u-hide--medium">


### PR DESCRIPTION
Section was removed accidentally in the past, so I revived it using https://github.com/canonical/multipass.run/commit/6c29098de633d5b6f459a5ab8faa7e583995b33e

## QA
Check https://multipass-run-292.demos.haus/ has the cheatsheet section back, compare with [copy doc](https://docs.google.com/document/d/1uI5hsuhe5VUpFSSiQas6FVB2F7RhlbNXcr5Pvr_Lm2c/edit?disco=AAAArmTOY2M)

## Issue

Fixes [WD-2206](https://warthogs.atlassian.net/browse/WD-2206?atlOrigin=eyJpIjoiMzg2MmRmNWMyM2M1NDIzNTk2NjMzMzYyZjgyNjBlNGEiLCJwIjoiaiJ9)

[WD-2206]: https://warthogs.atlassian.net/browse/WD-2206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ