### PR TITLE
Update github issue link

### DIFF
--- a/templates/_layouts/default.html
+++ b/templates/_layouts/default.html
@@ -89,7 +89,7 @@
             </li>
             <li class="p-inline-list__item">
               <a
-                href="https://github.com/canonical/multipass/issues/new">
+                href="https://github.com/canonical/multipass/issues/new/choose">
                 Report a bug on Multipass itself
               </a>
             </li>


### PR DESCRIPTION
Update the github issue link so that users can choose an issue type and aren't given a blank form.