### PR TITLE
Prepare for new theming of navigation

### DIFF
--- a/static/sass/_settings_colors.scss
+++ b/static/sass/_settings_colors.scss
@@ -1,4 +1,3 @@
-$theme-default-nav: dark;
 $color-brand: #e95420;
 $color-suru-start: #2c001e;
 $color-suru-middle: #772953;

--- a/templates/_layouts/default.html
+++ b/templates/_layouts/default.html
@@ -32,7 +32,7 @@
 
 <script async defer src="https://buttons.github.io/buttons.js"></script>
 
-  <header id="navigation" class="p-navigation">
+  <header id="navigation" class="p-navigation is-dark">
     <div class="p-navigation__row">
       <div class="p-navigation__banner">
       <div class="p-navigation__tagged-logo">


### PR DESCRIPTION
## Done

Vanilla 4.10.0 is going to update top navigation to new theming and deprecates the use of `$theme-default-nav` variable.

This PR prepares for that by using `is-dark` class name on top nav.

## QA

- Check the demo: 
- Make sure that top navigation displays as dark and has `is-dark` class name on `p-navigation` element


## Issue / Card

Related to: https://warthogs.atlassian.net/browse/WD-7594

