### PR TITLE
WD-12938 - update canonicalwebteam.discourse to 5.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 canonicalwebteam.flask-base==1.1.0
-canonicalwebteam.discourse==5.6.0
+canonicalwebteam.discourse==5.6.1
 canonicalwebteam.search==1.3.0


### PR DESCRIPTION
## Done

Bump canonicalwebteam.discourse to 5.6.1

## QA

- Check that the changes in vanilla have not broken anything

## Issue / Card
[WD-12938](https://warthogs.atlassian.net/browse/WD-12938)

[WD-12938]: https://warthogs.atlassian.net/browse/WD-12938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ