### PR TITLE
WD-13370 Bumped cookie-policy to v3.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test-python": "python3 -m unittest discover tests"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "3.5.0",
+    "@canonical/cookie-policy": "3.6.4",
     "@canonical/global-nav": "3.6.4",
     "@canonical/discourse-rad-parser": "1.0.1",
     "autoprefixer": "10.4.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@canonical/cookie-policy@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.5.0.tgz#1c7e6cc2d5a7218375001b2cff2996a927693e89"
-  integrity sha512-XLCIl8+h+3BRfvqADqFsmAfWdaDGDchY/TPCKtpeQdb4r64SR6arsdNftlOb7vX8EuLCK2QRp6evUy0J+qnQTg==
+"@canonical/cookie-policy@3.6.4":
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.6.4.tgz#895c3770f621b73d88b0d5843c43a32d99e4a462"
+  integrity sha512-kfwamTpAaBhtH5TzlMb8wE814a8lIbONUuSYnS7VPiHDfcdmw4NoBPNpldmNY1j3CAT5vMKOx5kulRTWpEXpag==
 
 "@canonical/discourse-rad-parser@1.0.1":
   version "1.0.1"


### PR DESCRIPTION
## Done

Bumped cookie-policy to v3.6.4
## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8026/
    - Be sure to test on mobile, tablet and desktop screen sizes
- Delete cookies so you get the cookie policy pop up
- Accept nothing and check that in cookies there exists `_cookies_accepted=essential`
- Repeat with only accept 'performance', only accepting 'functional' and finally 'all'
## Issue / Card

Fixes #  [WD-13370](https://warthogs.atlassian.net/browse/WD-13370)

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)

[WD-13370]: https://warthogs.atlassian.net/browse/WD-13370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ