### PR TITLE
Upgrade canonicalwebteam.search to 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ Codebase for https://multipass.run - the marketing website for Canonical's multi
 
 ## Local development
 
-The simplest way to run the site locally is to first [install Docker](https://docs.docker.com/engine/installation/) (on Linux you may need to [add your user to the `docker` group](https://docs.docker.com/engine/installation/linux/linux-postinstall/)), and then use the `./run` script:
+The simplest way to run the site locally is with the dotrun snap:
 
 ```bash
-./run
+dotrun
 ```
 
 Once the containers are setup, you can visit <http://127.0.0.1:8026> in your browser.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "sass": "1.57.1",
     "postcss": "8.4.31",
     "postcss-cli": "10.1.0",
-    "vanilla-framework": "4.14.0"
+    "vanilla-framework": "4.16.0"
   },
   "devDependencies": {
     "prettier": "2.8.8",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-canonicalwebteam.flask-base==1.1.0
+canonicalwebteam.flask-base==2.0.0
 canonicalwebteam.discourse==5.6.1
-canonicalwebteam.search==1.3.0
+canonicalwebteam.search==2.1.1

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -85,9 +85,11 @@ app.add_url_rule(
     "/docs/search",
     "docs-search",
     build_search_view(
+        app=app,
         session=session,
         site="multipass.run/docs",
         template_path="docs/search.html",
+        request_limit="1/day",
     ),
 )
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -89,7 +89,6 @@ app.add_url_rule(
         session=session,
         site="multipass.run/docs",
         template_path="docs/search.html",
-        request_limit="1/day",
     ),
 )
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1550,10 +1550,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@4.14.0:
-  version "4.14.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.14.0.tgz#dca425c806462179467030ac30ef496997e2d8cb"
-  integrity sha512-YctHWwH1SbIltBMMVdeiVW1QtxVjaU15jLKiubgVjE9AByuK/EriyZnPQkXtb/+Rwf1mtF24rae+mmG8aFqUJw==
+vanilla-framework@4.16.0:
+  version "4.16.0"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-4.16.0.tgz#54e7a51e073de043d45a7bac37ffaa4f4351ac4a"
+  integrity sha512-LrxZLiNOm0cTpG++1X4MMy2efg8Xhc08JUAwNAybeSQ5FaaBGiAodbV1Fx3QvJxlaPFQqsjOdT6uZDwuOD7YJg==
 
 vanilla-framework@4.9.0:
   version "4.9.0"


### PR DESCRIPTION

## Done

- Upgrade canonicalwebteam.search to 2.1.1
- Upgrade canonicalwebteam.flask-base to 2.0.0
- Pass `app` to `build_search_view()`
- Bump vanilla-framework to 4.16.0

## QA

- Go to https://multipass-run-340.demos.haus/docs/search
- Search something
- See rate limit is hit (currently set to 1, so you can search 1 time before hitting it)


## Issue / Card

Fixes https://warthogs.atlassian.net/browse/WD-15014

## Screenshots

![image](https://github.com/user-attachments/assets/48739638-870b-426f-818a-0a9983cea3dc)
