### PR TITLE
Remove reference to deprecated Multipass backend hypervisor

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,8 @@
     <div class="col-7">
       <h3>VMs for Windows, macOS and Linux</h3>
       <p class="p-heading--4">Start Ubuntu VMs with each platform's native hypervisor</p>
-      <p>Multipass uses Hyper-V on Windows, QEMU and HyperKit on macOS and LXD on Linux for minimal overhead and the fastest possible start time. <a href="/docs/set-up-the-driver">Switching your hypervisor to Virtualbox</a> is a breeze.</p>
+      <p>Multipass uses Hyper-V on Windows, and QEMU on macOS and Linux for minimal overhead and the fastest possible start
+        time. <a href="/docs/set-up-the-driver">Switching your hypervisor to Virtualbox</a> is a breeze.</p>
     </div>
     <div class="col-5 u-hide--small u-hide--medium u-align--center">
       <img src="https://assets.ubuntu.com/v1/c5602a1a-VMs-Windows-Linux-Mac.svg" style="height: 171px; width: 300px;" alt=""/>


### PR DESCRIPTION
## Done

- Removed a text reference to Hyperkit which was deprecated in Multipass v1.13. Release notes located [here](https://github.com/canonical/multipass/releases/tag/v1.13.0)