### PR TITLE
Invoke cookie policy before gtm

### DIFF
--- a/templates/_layouts/default.html
+++ b/templates/_layouts/default.html
@@ -23,6 +23,9 @@
     <link rel="manifest" href="{{ versioned_static("files/site.webmanifest") }}" />
     <!-- Serving favicon for search engines locally -->
     <link rel="icon" type="image/png" sizes="48x48" href="{{ versioned_static("favicons/COF-favicon-48x48.png") }}" />
+    <!-- Cookie policy -->
+    <script src="{{ versioned_static('js/modules/cookie-policy.js')}}"></script>
+    <script>cpNs.cookiePolicy();</script>
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -49,11 +52,9 @@
       </div>
       {% include "_layouts/_footer.html" %}
     {% endblock body %}
-    <script src="{{ versioned_static('js/modules/global-nav.js') }}"></script>
-    <script src="{{ versioned_static('js/modules/cookie-policy.js')}}"></script>
+    <script src="{{ versioned_static('js/modules/global-nav.js') }}"></script>    
     <script src="{{ versioned_static('js/tabs.js') }}"></script>
-    <script>
-    cpNs.cookiePolicy();
+    <script>    
     if (typeof canonicalGlobalNav !== "undefined") {
       canonicalGlobalNav.createNav({breakpoint: 1035});
     }


### PR DESCRIPTION
## Done

- Call cookie policy script before GTM

## QA

- Check out this feature branch
- Run the site using the command `./run serve` or `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8026/
    - Be sure to test on mobile, tablet and desktop screen sizes
- [List additional steps to QA the new features or prove the bug has been resolved]

## Issue / Card

Fixes #

## Screenshots

[If relevant, please include a screenshot.]


## Help

[QA steps](https://discourse.canonical.com/t/qa-steps/152) - [Commit guidelines](https://discourse.canonical.com/t/commit-guidelines/148)