### PR TITLE
Update latest-release.json for 1.14.1

### DIFF
--- a/static/latest-release.json
+++ b/static/latest-release.json
@@ -1,11 +1,11 @@
 {
-  "version": "1.14.0",
-  "title": "Multipass 1.14.0 release",
+  "version": "1.14.1",
+  "title": "Multipass 1.14.1 release",
   "description": "New GUI, bridge addition, force-stop, snapshots extended to VirtualBox",
   "download_url": "https://multipass.run/#install",
-  "release_url": "https://github.com/canonical/multipass/releases/tag/v1.14.0",
+  "release_url": "https://github.com/canonical/multipass/releases/tag/v1.14.1",
   "installer_urls": {
-    "windows": "https://github.com/canonical/multipass/releases/download/v1.14.0/multipass-1.14.0+win-win64.exe",
-    "macos": "https://github.com/canonical/multipass/releases/download/v1.14.0/multipass-1.14.0+mac-Darwin.pkg"
+    "windows": "https://github.com/canonical/multipass/releases/download/v1.14.1/multipass-1.14.1+win-win64.exe",
+    "macos": "https://github.com/canonical/multipass/releases/download/v1.14.1/multipass-1.14.1+mac-Darwin.pkg"
   }
 }


### PR DESCRIPTION
For reference: https://github.com/canonical/multipass/releases/tag/v1.14.1